### PR TITLE
Fix: parsing strings containing large numbers

### DIFF
--- a/YamlSerializer/YamlTagResolver.cs
+++ b/YamlSerializer/YamlTagResolver.cs
@@ -25,8 +25,9 @@ namespace YamlSerializer
         /// </summary>
         void AddDefaultRules()
         {
+            int max_digits_in_int = int.MaxValue.ToString().Length - 2;
             BeginUpdate();
-            AddRule<int>("!!int", @"([-+]?(0|[1-9][0-9_]*))", 
+            AddRule<int>("!!int", @"([-+]?(0|[1-9][0-9_]{0," + max_digits_in_int.ToString() + "}))", 
                 m => Convert.ToInt32(m.Value.Replace("_", "")), null);
             AddRule<int>("!!int", @"([-+]?)0b([01_]+)", m => {
                 var v = Convert.ToInt32(m.Groups[2].Value.Replace("_", ""), 2);

--- a/YamlSerializer/YamlTagResolver.cs
+++ b/YamlSerializer/YamlTagResolver.cs
@@ -51,8 +51,8 @@ namespace YamlSerializer
             AddRule<double>("!!float", @"\+?(\.inf|\.Inf|\.INF)", m => double.PositiveInfinity, null);
             AddRule<double>("!!float", @"-(\.inf|\.Inf|\.INF)", m => double.NegativeInfinity, null);
             AddRule<double>("!!float", @"\.nan|\.NaN|\.NAN", m => double.NaN, null);
-            AddRule<bool>("!!bool", @"y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON", m => true, null);
-            AddRule<bool>("!!bool", @"n|N|no|No|NO|false|False|FALSE|off|Off|OFF", m => false, null);
+            AddRule<bool>("!!bool", @"yes|Yes|YES|true|True|TRUE|on|On|ON", m => true, null);
+            AddRule<bool>("!!bool", @"no|No|NO|false|False|FALSE|off|Off|OFF", m => false, null);
             AddRule<object>("!!null", @"null|Null|NULL|\~|", m => null, null);
             AddRule<string>("!!merge", @"<<", m => "<<", null);
             AddRule<DateTime>("!!timestamp",  // Todo: spec is wrong (([ \t]*)Z|[-+][0-9][0-9]?(:[0-9][0-9])?)? should be (([ \t]*)(Z|[-+][0-9][0-9]?(:[0-9][0-9])?))? to accept "2001-12-14 21:59:43.10 -5"


### PR DESCRIPTION
There was a bug that would crash (overflow exception) serialization
when serializing strings that contain large numbers, for instance
"999999999876", which is a legal string, but for some reason
serializer wants to temporarilly transfor it to an int - which causes
an expected exception, as it is too big for an int.

To avoid this, added limit of how many digits should be
considered numbers.

Signed-off-by: zeljko zeljko@zwr.fi
